### PR TITLE
Expanded MSI until for use in CSE Linux

### DIFF
--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -20,7 +20,7 @@ var dummyMetadataJson = `{
             "platformFaultDomain": "0",
             "platformUpdateDomain": "0",
             "publisher": "some-publisher",
-            "resourceGroupName": "rome-resourceGroup",
+            "resourceGroupName": "some-resourceGroup",
             "sku": "some-sku",
             "subscriptionId": "aaaa0000-aa00-aa00-aa00-aaaaaa000000",
             "tags": "",

--- a/msi/msi.go
+++ b/msi/msi.go
@@ -16,7 +16,7 @@ import (
 const (
 	metadataMsiBaseURL = "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01"
 
-	clinetIdQueryparm  = "client_id"
+	clinetIdQueryparam = "client_id"
 	objectIdQueryparam = "object_id"
 	resourceQueryparam = "resource"
 
@@ -79,13 +79,13 @@ func (p *provider) GetMsi() (Msi, error) {
 	return *msi, err
 }
 
-func (p *provider) GetMsiForResoruce(targetResource string) (Msi, error) {
+func (p *provider) GetMsiForResource(targetResource string) (Msi, error) {
 	msi, err := p.getMsiHelper(map[string]string{resourceQueryparam: targetResource})
 	return *msi, err
 }
 
 func (p *provider) GetMsiUsingClientId(clientId string, targetResource string) (Msi, error) {
-	msi, err := p.getMsiHelper(map[string]string{clinetIdQueryparm: clientId, resourceQueryparam: targetResource})
+	msi, err := p.getMsiHelper(map[string]string{clinetIdQueryparam: clientId, resourceQueryparam: targetResource})
 	return *msi, err
 }
 

--- a/msi/msi.go
+++ b/msi/msi.go
@@ -53,9 +53,11 @@ func (p *provider) getMsiHelper(queryParams map[string]string) (*Msi, error) {
 	if err != nil {
 		return &msi, err
 	}
+	urlQuery := requestUrl.Query()
 	for key, value := range queryParams {
-		requestUrl.Query().Add(key, value)
+		urlQuery.Add(key, value)
 	}
+	requestUrl.RawQuery = urlQuery.Encode()
 
 	code, body, err := p.httpClient.Get(requestUrl.String(), map[string]string{"Metadata": "true"})
 	if err != nil {

--- a/msi/msi.go
+++ b/msi/msi.go
@@ -14,13 +14,13 @@ import (
 )
 
 const (
-	metadataMsiBaseURL = "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01"
+	metadataIdentityURL = "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01"
 
-	clinetIdQueryparam = "client_id"
-	objectIdQueryparam = "object_id"
-	resourceQueryparam = "resource"
+	clinetIdQueryParam = "client_id"
+	objectIdQueryParam = "object_id"
+	resourceQueryParam = "resource"
 
-	amrResourceUri = "https://management.core.windows.net/"
+	armResourceUri = "https://management.core.windows.net/"
 )
 
 type Msi struct {
@@ -48,7 +48,7 @@ func NewMsiProvider(client httputil.HttpClient) provider {
 
 func (p *provider) getMsiHelper(queryParams map[string]string) (*Msi, error) {
 	var msi = Msi{}
-	requestUrl, err := url.Parse(metadataMsiBaseURL)
+	requestUrl, err := url.Parse(metadataIdentityURL)
 	if err != nil {
 		return &msi, err
 	}
@@ -75,22 +75,22 @@ func (p *provider) getMsiHelper(queryParams map[string]string) (*Msi, error) {
 }
 
 func (p *provider) GetMsi() (Msi, error) {
-	msi, err := p.getMsiHelper(map[string]string{resourceQueryparam: amrResourceUri})
+	msi, err := p.getMsiHelper(map[string]string{resourceQueryParam: armResourceUri})
 	return *msi, err
 }
 
 func (p *provider) GetMsiForResource(targetResource string) (Msi, error) {
-	msi, err := p.getMsiHelper(map[string]string{resourceQueryparam: targetResource})
+	msi, err := p.getMsiHelper(map[string]string{resourceQueryParam: targetResource})
 	return *msi, err
 }
 
 func (p *provider) GetMsiUsingClientId(clientId string, targetResource string) (Msi, error) {
-	msi, err := p.getMsiHelper(map[string]string{clinetIdQueryparam: clientId, resourceQueryparam: targetResource})
+	msi, err := p.getMsiHelper(map[string]string{clinetIdQueryParam: clientId, resourceQueryParam: targetResource})
 	return *msi, err
 }
 
 func (p *provider) GetMsiUsingObjectId(objectId string, targetResource string) (Msi, error) {
-	msi, err := p.getMsiHelper(map[string]string{objectIdQueryparam: objectId, resourceQueryparam: targetResource})
+	msi, err := p.getMsiHelper(map[string]string{objectIdQueryParam: objectId, resourceQueryParam: targetResource})
 	return *msi, err
 }
 

--- a/msi/msi.go
+++ b/msi/msi.go
@@ -14,7 +14,6 @@ import (
 )
 
 const (
-	metadataMsiURL     = "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.core.windows.net/"
 	metadataMsiBaseURL = "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01"
 
 	clinetIdQueryparm  = "client_id"

--- a/msi/msi.go
+++ b/msi/msi.go
@@ -16,7 +16,7 @@ import (
 const (
 	metadataIdentityURL = "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01"
 
-	clinetIdQueryParam = "client_id"
+	clientIdQueryParam = "client_id"
 	objectIdQueryParam = "object_id"
 	resourceQueryParam = "resource"
 
@@ -85,7 +85,7 @@ func (p *provider) GetMsiForResource(targetResource string) (Msi, error) {
 }
 
 func (p *provider) GetMsiUsingClientId(clientId string, targetResource string) (Msi, error) {
-	msi, err := p.getMsiHelper(map[string]string{clinetIdQueryParam: clientId, resourceQueryParam: targetResource})
+	msi, err := p.getMsiHelper(map[string]string{clientIdQueryParam: clientId, resourceQueryParam: targetResource})
 	return *msi, err
 }
 

--- a/msi/msi.go
+++ b/msi/msi.go
@@ -36,6 +36,9 @@ type Msi struct {
 
 type MsiProvider interface {
 	GetMsi() (Msi, error)
+	GetMsiForResource(targetResource string) (Msi, error)
+	GetMsiUsingClientId(clientId string, targetResource string) (Msi, error)
+	GetMsiUsingObjectId(objectId string, targetResource string) (Msi, error)
 }
 
 type provider struct {

--- a/msi/msi_test.go
+++ b/msi/msi_test.go
@@ -75,3 +75,45 @@ func TestCanGetMsi(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 }
+
+func TestCanGetMsiForStorage(t *testing.T) {
+	t.Skip() // for testing on Azure VM only
+	outdir := "./testoutput"
+	os.Mkdir(outdir, 0777)
+	secureHttpClient := httputil.NewSecureHttpClient(httputil.NoRetry)
+	msiProvider := NewMsiProvider(secureHttpClient)
+	msi, err := msiProvider.GetMsiForResoruce("https://storage.azure.com/")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	t.Logf("Successfully got msi token.\nClientId was : %s", msi.ClientID)
+	msiJsonBytes, err := json.Marshal(msi)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = ioutil.WriteFile(fmt.Sprintf("%s/msi.json", outdir), msiJsonBytes[:], 0700)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
+func TestCanGetMsiForKeyVault(t *testing.T) {
+	t.Skip() // for testing on Azure VM only
+	outdir := "./testoutput"
+	os.Mkdir(outdir, 0777)
+	secureHttpClient := httputil.NewSecureHttpClient(httputil.NoRetry)
+	msiProvider := NewMsiProvider(secureHttpClient)
+	msi, err := msiProvider.GetMsiForResoruce("https://vault.azure.net")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	t.Logf("Successfully got msi token.\nClientId was : %s", msi.ClientID)
+	msiJsonBytes, err := json.Marshal(msi)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = ioutil.WriteFile(fmt.Sprintf("%s/msi.json", outdir), msiJsonBytes[:], 0700)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}

--- a/msi/msi_test.go
+++ b/msi/msi_test.go
@@ -70,7 +70,7 @@ func TestCanGetMsi(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	err = ioutil.WriteFile(fmt.Sprintf("%s/msi.json", outdir), msiJsonBytes[:], 0700)
+	err = ioutil.WriteFile(fmt.Sprintf("%s/msi1.json", outdir), msiJsonBytes[:], 0700)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -113,6 +113,48 @@ func TestCanGetMsiForKeyVault(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	err = ioutil.WriteFile(fmt.Sprintf("%s/msi3.json", outdir), msiJsonBytes[:], 0700)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
+func TestCanGetMsiForKeyVaultWithClientId(t *testing.T) {
+	t.Skip() // for testing on Azure VM only
+	outdir := "./testoutput"
+	os.Mkdir(outdir, 0777)
+	secureHttpClient := httputil.NewSecureHttpClient(httputil.NoRetry)
+	msiProvider := NewMsiProvider(secureHttpClient)
+	msi, err := msiProvider.GetMsiUsingClientId("31b403aa-c364-4240-a7ff-d85fb6cd7232", "https://vault.azure.net")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	t.Logf("Successfully got msi token.\nClientId was : %s", msi.ClientID)
+	msiJsonBytes, err := json.Marshal(msi)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = ioutil.WriteFile(fmt.Sprintf("%s/msi4.json", outdir), msiJsonBytes[:], 0700)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
+func TestCanGetMsiForStoragetWithObjectId(t *testing.T) {
+	t.Skip() // for testing on Azure VM only
+	outdir := "./testoutput"
+	os.Mkdir(outdir, 0777)
+	secureHttpClient := httputil.NewSecureHttpClient(httputil.NoRetry)
+	msiProvider := NewMsiProvider(secureHttpClient)
+	msi, err := msiProvider.GetMsiUsingObjectId("20931e04-e65f-4526-8c01-9d627f577263", "https://storage.azure.com/")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	t.Logf("Successfully got msi token.\nClientId was : %s", msi.ClientID)
+	msiJsonBytes, err := json.Marshal(msi)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = ioutil.WriteFile(fmt.Sprintf("%s/msi5.json", outdir), msiJsonBytes[:], 0700)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/msi/msi_test.go
+++ b/msi/msi_test.go
@@ -124,6 +124,7 @@ func TestCanGetMsiForKeyVaultWithClientId(t *testing.T) {
 	os.Mkdir(outdir, 0777)
 	secureHttpClient := httputil.NewSecureHttpClient(httputil.NoRetry)
 	msiProvider := NewMsiProvider(secureHttpClient)
+	// change client id to match your user managed identity
 	msi, err := msiProvider.GetMsiUsingClientId("31b403aa-c364-4240-a7ff-d85fb6cd7232", "https://vault.azure.net")
 	if err != nil {
 		t.Fatal(err.Error())
@@ -145,6 +146,7 @@ func TestCanGetMsiForStoragetWithObjectId(t *testing.T) {
 	os.Mkdir(outdir, 0777)
 	secureHttpClient := httputil.NewSecureHttpClient(httputil.NoRetry)
 	msiProvider := NewMsiProvider(secureHttpClient)
+	// change object id to match your user managed identity
 	msi, err := msiProvider.GetMsiUsingObjectId("20931e04-e65f-4526-8c01-9d627f577263", "https://storage.azure.com/")
 	if err != nil {
 		t.Fatal(err.Error())

--- a/msi/msi_test.go
+++ b/msi/msi_test.go
@@ -91,7 +91,7 @@ func TestCanGetMsiForStorage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	err = ioutil.WriteFile(fmt.Sprintf("%s/msi.json", outdir), msiJsonBytes[:], 0700)
+	err = ioutil.WriteFile(fmt.Sprintf("%s/msi2.json", outdir), msiJsonBytes[:], 0700)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -112,7 +112,7 @@ func TestCanGetMsiForKeyVault(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	err = ioutil.WriteFile(fmt.Sprintf("%s/msi.json", outdir), msiJsonBytes[:], 0700)
+	err = ioutil.WriteFile(fmt.Sprintf("%s/msi3.json", outdir), msiJsonBytes[:], 0700)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/msi/msi_test.go
+++ b/msi/msi_test.go
@@ -82,7 +82,7 @@ func TestCanGetMsiForStorage(t *testing.T) {
 	os.Mkdir(outdir, 0777)
 	secureHttpClient := httputil.NewSecureHttpClient(httputil.NoRetry)
 	msiProvider := NewMsiProvider(secureHttpClient)
-	msi, err := msiProvider.GetMsiForResoruce("https://storage.azure.com/")
+	msi, err := msiProvider.GetMsiForResource("https://storage.azure.com/")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -103,7 +103,7 @@ func TestCanGetMsiForKeyVault(t *testing.T) {
 	os.Mkdir(outdir, 0777)
 	secureHttpClient := httputil.NewSecureHttpClient(httputil.NoRetry)
 	msiProvider := NewMsiProvider(secureHttpClient)
-	msi, err := msiProvider.GetMsiForResoruce("https://vault.azure.net")
+	msi, err := msiProvider.GetMsiForResource("https://vault.azure.net")
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/msihttpclient/msihttpclient_test.go
+++ b/msihttpclient/msihttpclient_test.go
@@ -44,6 +44,18 @@ func (prov *mockMsiProvider) GetMsi() (msi.Msi, error) {
 	return *prov.dummyMsi, nil
 }
 
+func (prov *mockMsiProvider) GetMsiForResource(targetResource string) (msi.Msi, error) {
+	return msi.Msi{}, nil
+}
+
+func (prov *mockMsiProvider) GetMsiUsingClientId(clientId string, targetResource string) (msi.Msi, error) {
+	return msi.Msi{}, nil
+}
+
+func (prov *mockMsiProvider) GetMsiUsingObjectId(objectId string, targetResource string) (msi.Msi, error) {
+	return msi.Msi{}, nil
+}
+
 type mockHttpClient struct {
 	AttemptCount *int
 	DoFunc       func(i *int, req *http.Request) (*http.Response, error)


### PR DESCRIPTION
Expanded MSI until for use in CSE Linux.
MSI util can now get MSI using client_id and object_id and can the token for specified resource.