### PR TITLE
Renames module from msi to repo name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
-module msi
+module github.com/Azure/azure-extension-foundation
 
 go 1.23
-
-require github.com/Azure/azure-extension-foundation v0.0.0-20230404211847-9858bdd5c187
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect


### PR DESCRIPTION
Rename module so import in extensions repos (RCv2) doesn't cause below error: 

go: github.com/Azure/azure-extension-foundation@v0.0.0-20250107190602-e97d4a8b6a28: parsing go.mod:
        module declares its path as: msi
                but was required as: github.com/Azure/azure-extension-foundation