### PR TITLE
Adds support for getting a MSI token from HIMDS (Arc)

### DIFF
--- a/httputil/mockclient.go
+++ b/httputil/mockclient.go
@@ -3,12 +3,15 @@
 
 package httputil
 
+import "net/http"
+
 type MockHttpClient struct {
 	// overwrite these methods to get the desired output
-	Getfunc    func(url string, headers map[string]string) (responseCode int, body []byte, err error)
-	Postfunc   func(url string, headers map[string]string, payload []byte) (responseCode int, body []byte, err error)
-	Putfunc    func(url string, headers map[string]string, payload []byte) (responseCode int, body []byte, err error)
-	Deletefunc func(url string, headers map[string]string, payload []byte) (responseCode int, body []byte, err error)
+	Getfunc            func(url string, headers map[string]string) (responseCode int, body []byte, err error)
+	GetfuncWithHeaders func(url string, headers map[string]string) (responseCode int, respHeaders http.Header, body []byte, err error)
+	Postfunc           func(url string, headers map[string]string, payload []byte) (responseCode int, body []byte, err error)
+	Putfunc            func(url string, headers map[string]string, payload []byte) (responseCode int, body []byte, err error)
+	Deletefunc         func(url string, headers map[string]string, payload []byte) (responseCode int, body []byte, err error)
 }
 
 func (client *MockHttpClient) Get(url string, headers map[string]string) (responseCode int, body []byte, err error) {
@@ -23,4 +26,8 @@ func (client *MockHttpClient) Put(url string, headers map[string]string, payload
 }
 func (client *MockHttpClient) Delete(url string, headers map[string]string, payload []byte) (responseCode int, body []byte, err error) {
 	return client.Deletefunc(url, headers, payload)
+}
+
+func (client *MockHttpClient) GetWithHeaders(url string, headers map[string]string) (responseCode int, respHeaders http.Header, body []byte, err error) {
+	return client.GetfuncWithHeaders(url, headers)
 }

--- a/msi/msi_test.go
+++ b/msi/msi_test.go
@@ -172,8 +172,9 @@ func TestCanGetImdsVariable(t *testing.T) {
 	}
 
 	//setting env var - should return test (or whatever var is set to)
-	testVar := "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2024-12-19"
-	os.Setenv(identityEnvVar, testVar)
+	identityEndpoint := "http://localhost:40342/metadata/identity/oauth2/token"
+	testVar := "http://localhost:40342/metadata/identity/oauth2/token?api-version=2021-02-01"
+	os.Setenv(identityEnvVar, identityEndpoint)
 	url = GetMetadataIdentityURL()
 	if url != testVar {
 		t.Fatal("mismatch URLs")


### PR DESCRIPTION
Arc uses a challenge response mechanism to get a token. This involves HIMDS responding with a 401 and a location to the token in the header. Next call must be made with the Basic authorization header to get the MSI token. 

TestCanGetMsiForStorage and TestCanGetMsi have been run locally in an Arc environment.